### PR TITLE
Fix for FIPS use case

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
@@ -138,31 +138,37 @@ public class CertUtils {
 
       throw new InvalidKeySpecException("Unknown type of PKCS8 Private Key, tried RSA and ECDSA");
   }
-
-  private static PrivateKey handleECKey(InputStream keyInputStream) {
-    // Let's wrap the code to a callable inner class to avoid NoClassDef when loading this class.
+  
+  private static void addStandardBCProvider()
+  {
     try {
-      return new Callable<PrivateKey>() {
-        @Override
-        public PrivateKey call() {
-          try {
-            if (Security.getProvider("BC") == null && Security.getProvider("BCFIPS") == null) {
-              Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
-            }
-            PEMKeyPair keys = (PEMKeyPair) new PEMParser(new InputStreamReader(keyInputStream)).readObject();
-            return new
-              JcaPEMKeyConverter().
-              getKeyPair(keys).
-              getPrivate();
-          } catch (IOException exception) {
-            exception.printStackTrace();
-          }
-          return null;
-        }
+      new Callable<Object>() {
+      	@Override
+      	public Object call() throws NoClassDefFoundError {
+      		Security.addProvider(new BouncyCastleProvider());
+      		return null;
+      	}
       }.call();
     } catch (NoClassDefFoundError e) {
       throw new KubernetesClientException("JcaPEMKeyConverter is provided by BouncyCastle, an optional dependency. To use support for EC Keys you must explicitly add this dependency to classpath.");
     }
+  }
+
+  private static PrivateKey handleECKey(InputStream keyInputStream) {
+    // Let's wrap the code to a callable inner class to avoid NoClassDef when loading this class.
+    try {
+      if (Security.getProvider("BC") == null && Security.getProvider("BCFIPS") == null) {
+        addStandardBCProvider();
+      }
+      PEMKeyPair keys = (PEMKeyPair) new PEMParser(new InputStreamReader(keyInputStream)).readObject();
+      return new
+        JcaPEMKeyConverter().
+        getKeyPair(keys).
+        getPrivate();
+    } catch (IOException exception) {
+      exception.printStackTrace();
+    }
+    return null;
   }
 
   private static PrivateKey handleOtherKeys(InputStream keyInputStream, String clientKeyAlgo) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {


### PR DESCRIPTION
The code as it was does not work with FIPS, because the class name is different. The check for BCFIPS shows the coder expected this use case, but having the instantiation of the standard BC provider class hard coded inside the Callable<> made the NoClassDefFoundError unavoidable in the FIPS case.

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
 - [x] I tested the fix with a local K3D cluster

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
